### PR TITLE
update endpoint url and add api key

### DIFF
--- a/src/tileUtilities.js
+++ b/src/tileUtilities.js
@@ -3,8 +3,9 @@ import _ from 'underscore';
 
 import { degreesToMeters } from './utils';
 
-const baseElevationURL = 'https://terrain-preview.mapzen.com/terrarium';
+const baseElevationURL = 'https://tile.mapzen.com/mapzen/terrain/v1/terrarium';
 const baseImageURL = 'http://tile.stamen.com/terrain';
+const baseElevationAPIKEY = "mapzen-xxxxxxx" // get your key here: http://mapzen.com/developers
 
 export const long2tile = (lon, zoom) => {
   return (Math.floor((lon + 180) / 360 * Math.pow(2, zoom)));
@@ -18,7 +19,7 @@ export const lat2tile = (lat, zoom) => {
 export const fetchElevationTile = (lon, lat, zoom) => {
   let x = long2tile(lon, zoom);
   let y = lat2tile(lat, zoom);
-  let url = baseElevationURL + '/' + zoom + '/' + x + '/' + y + '.png';
+  let url = baseElevationURL + '/' + zoom + '/' + x + '/' + y + '.png' + '?api_key=' + baseElevationAPIKEY;
 
   return fetch(url);
 };


### PR DESCRIPTION
The terrain-preview endpoint is retired – also API keys are now required!

Read more here:

https://mapzen.com/blog/terrain-tile-service/
https://mapzen.com/blog/api-keys-required/
👍 